### PR TITLE
Replace \ in / for import names

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -313,6 +313,7 @@ func (p *parser) parseModule() error {
 			}
 			// p.debug(path)
 			name := filepath.Join(p.ModuleName, strings.TrimPrefix(path, p.ModulePath))
+			name = strings.ReplaceAll(name, `\`, `/`)
 			p.KnownPkgs = append(p.KnownPkgs, pkg{
 				Name: name,
 				Path: path,
@@ -347,6 +348,7 @@ func (p *parser) parseGoMod() error {
 		}
 		pkgName := goMod.Requires[i].Path
 		pkgPath := filepath.Join(p.GoModCachePath, string(pathRunes)+"@"+goMod.Requires[i].Version)
+		pkgName = strings.ReplaceAll(pkgName, `\`, `/`)
 		p.KnownPkgs = append(p.KnownPkgs, pkg{
 			Name: pkgName,
 			Path: pkgPath,
@@ -365,6 +367,7 @@ func (p *parser) parseGoMod() error {
 				}
 				// p.debug(path)
 				name := filepath.Join(pkgName, strings.TrimPrefix(path, pkgPath))
+				name = strings.ReplaceAll(name, `\`, `/`)
 				p.KnownPkgs = append(p.KnownPkgs, pkg{
 					Name: name,
 					Path: path,

--- a/parser.go
+++ b/parser.go
@@ -313,7 +313,7 @@ func (p *parser) parseModule() error {
 			}
 			// p.debug(path)
 			name := filepath.Join(p.ModuleName, strings.TrimPrefix(path, p.ModulePath))
-			name = strings.ReplaceAll(name, `\`, `/`)
+			name = filepath.ToSlash(name)
 			p.KnownPkgs = append(p.KnownPkgs, pkg{
 				Name: name,
 				Path: path,
@@ -348,7 +348,7 @@ func (p *parser) parseGoMod() error {
 		}
 		pkgName := goMod.Requires[i].Path
 		pkgPath := filepath.Join(p.GoModCachePath, string(pathRunes)+"@"+goMod.Requires[i].Version)
-		pkgName = strings.ReplaceAll(pkgName, `\`, `/`)
+		pkgName = filepath.ToSlash(pkgName)
 		p.KnownPkgs = append(p.KnownPkgs, pkg{
 			Name: pkgName,
 			Path: pkgPath,
@@ -367,7 +367,7 @@ func (p *parser) parseGoMod() error {
 				}
 				// p.debug(path)
 				name := filepath.Join(pkgName, strings.TrimPrefix(path, pkgPath))
-				name = strings.ReplaceAll(name, `\`, `/`)
+				name = filepath.ToSlash(name)
 				p.KnownPkgs = append(p.KnownPkgs, pkg{
 					Name: name,
 					Path: path,


### PR DESCRIPTION
On Windows systems, all paths are separated by a \\. Because of that,
deriving the package name from the path causes them to have a / where
the actual Go package name as a /.

Fixes #6 