### PR TITLE
consider parsing failures non-fatal

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var version = "v1.0.0"
+var version = "v1.0.1"
 
 var flags = []cli.Flag{
 	cli.StringFlag{
@@ -34,10 +34,14 @@ var flags = []cli.Flag{
 		Name:  "debug",
 		Usage: "show debug message",
 	},
+	cli.BoolFlag{
+		Name:  "strict",
+		Usage: "convert go parsing warnings to fatal errors",
+	},
 }
 
 func action(c *cli.Context) error {
-	p, err := newParser(c.GlobalString("module-path"), c.GlobalString("main-file-path"), c.GlobalString("handler-path"), c.GlobalBool("debug"))
+	p, err := newParser(c.GlobalString("module-path"), c.GlobalString("main-file-path"), c.GlobalString("handler-path"), c.GlobalBool("debug"), c.GlobalBool("strict"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Unfortunately due to how the parsing functions work, there are plenty of libraries that fail parsing and some potentially by design.

Some examples:
```
/Users/lazyshot/go/pkg/mod/golang.org/x/tools@v0.0.0-20201230224404-63754364767c/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0 package cause error: /Users/lazyshot/go/pkg/mod/golang.org/x/tools@v0.0.0-20201230224404-63754364767c/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0/main.go:1:16: expected ';', found '.'
```

```
2021/01/02 13:25:04 parsePaths: parse of /Users/bpeterson/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/integration/_fixtures/watch_fixtures/A package cause error: /Users/bpeterson/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/integration/_fixtures/watch_fixtures/A/A.go:3:8: invalid import path: "$ROOT_PATH$/B"
```

I don't expect any way for us to exclude those above scenarios in any pro-active way.