### PR TITLE
Extend struct tags with custom type and format

### DIFF
--- a/oas.go
+++ b/oas.go
@@ -144,6 +144,7 @@ type SchemaObject struct {
 	Items       *SchemaObject          `json:"items,omitempty"` // use ptr to prevent recursive error
 	Example     interface{}            `json:"example,omitempty"`
 	Deprecated  bool                   `json:"deprecated,omitempty"`
+	Nullable bool `json:"nullable,omitempty"`
 
 	// Ref is used when SchemaObject is as a ReferenceObject
 	Ref string `json:"$ref,omitempty"`
@@ -170,7 +171,6 @@ type SchemaObject struct {
 	// AdditionalProperties
 	// Description
 	// Default
-	// Nullable
 	// ReadOnly
 	// WriteOnly
 	// XML

--- a/oas.go
+++ b/oas.go
@@ -144,7 +144,7 @@ type SchemaObject struct {
 	Items       *SchemaObject          `json:"items,omitempty"` // use ptr to prevent recursive error
 	Example     interface{}            `json:"example,omitempty"`
 	Deprecated  bool                   `json:"deprecated,omitempty"`
-	Nullable bool `json:"nullable,omitempty"`
+	Nullable    bool                   `json:"nullable,omitempty"`
 
 	// Ref is used when SchemaObject is as a ReferenceObject
 	Ref string `json:"$ref,omitempty"`

--- a/parser.go
+++ b/parser.go
@@ -1150,6 +1150,16 @@ astFieldsLoop:
 					fieldSchema.Deprecated = true
 					continue astFieldsLoop
 				}
+				if kv := strings.Split(v, "="); len(kv) == 2 {
+					switch kv[0] {
+					case "type":
+						fieldSchema.Type = kv[1]
+						fieldSchema.Ref = ""
+
+					case "format":
+						fieldSchema.Format = kv[1]
+					}
+				}
 			}
 
 			if tag := astFieldTag.Get("json"); tag != "" {

--- a/parser.go
+++ b/parser.go
@@ -1158,6 +1158,9 @@ astFieldsLoop:
 
 					case "format":
 						fieldSchema.Format = kv[1]
+
+					case "nullable":
+						fieldSchema.Nullable, _ = strconv.ParseBool(kv[1])
 					}
 				}
 			}


### PR DESCRIPTION
Allows for custom type and custom format in the "goas" struct tag. This is f.e. for custom "Null"-types that are supposed to behave like nullable variants of standard types.
```
type Model struct {
    Active NullBool `json:"active" goas:"type=boolean"`
    Created NullTime `json:"created" goas:"type=string,format=date-time"`
}
```
with
```
type NullBool struct {
    Valid bool
    Bool bool
}
```
(NullBool and NullTime have their respective json marshaler to behave like bool and time.Time)